### PR TITLE
Fix script load order

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
             <a id="downloadLink" style="display:none;">Tải xuống PDF</a>
         </div>
     </div>
-    <script src="script.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load jsPDF before `script.js`

## Testing
- `curl -I https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js | head -n 5` *(fails: 403)*

------
https://chatgpt.com/codex/tasks/task_e_6842b1100988832f86599a8252146956