### PR TITLE
Fix progress bar visibility and base64 handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -43,6 +43,7 @@ document.getElementById('downloadForm').addEventListener('submit', async functio
 
     if (images.length === 0) {
         alert("Không tải được ảnh nào.");
+        progressContainer.style.display = 'none';
         return;
     }
 
@@ -105,5 +106,5 @@ function getBase64Image(img) {
     ctx.drawImage(img, 0, 0);
 
     const dataURL = canvas.toDataURL("image/jpeg");
-    return dataURL.replace(/^data:image\/(png|jpg);base64,/, "");
+    return dataURL.replace(/^data:image\/(png|jpg|jpeg);base64,/, "");
 }


### PR DESCRIPTION
## Summary
- hide the progress bar when no images were loaded
- handle `jpeg` base64 data when creating the PDF

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842b0818608832fa7be69abf9527b69